### PR TITLE
Adding support for configuring redis sentinels from env var

### DIFF
--- a/lib/sensu/redis.rb
+++ b/lib/sensu/redis.rb
@@ -61,7 +61,11 @@ module Sensu
         end
         options[:host] ||= "127.0.0.1"
         options[:port] ||= 6379
-        if options[:sentinels].is_a?(Array) && options[:sentinels].length > 0
+        case
+        when options[:sentinels].is_a?(String)
+          raw_urls = options[:sentinels]
+          options[:sentinels] = raw_urls.split(',').map { |url| parse_url(url) }
+        when options[:sentinels].is_a?(Array) && options[:sentinels].length > 0
           connect_via_sentinel(options, &block)
         else
           connect_direct(options, &block)

--- a/spec/redis_spec.rb
+++ b/spec/redis_spec.rb
@@ -25,4 +25,15 @@ describe "Sensu::Redis" do
       end
     end
   end
+
+  it "can connect to a redis master via comma-separated sentinel URL string", :sentinel => true do
+    async_wrapper do
+      Sensu::Redis.connect(:sentinels => "redis://127.0.0.1:26379,redis://127.0.0.1:26379") do |redis|
+        redis.callback do
+          expect(redis.connected?).to eq(true)
+          async_done
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
Implements partial support for feature described in sensu/sensu#1361

Relates to sensu/sensu-settings#41
