### PR TITLE
Redis sentinel "master_group" option

### DIFF
--- a/lib/sensu/redis/sentinel.rb
+++ b/lib/sensu/redis/sentinel.rb
@@ -12,7 +12,7 @@ module Sensu
       # @param options [Hash] containing the standard Redis
       #   connection settings.
       def initialize(options={})
-        @master = options[:master] || "mymaster"
+        @master = options[:master_group] || options[:master] || "mymaster"
         @sentinels = connect_to_sentinels(options[:sentinels])
       end
 


### PR DESCRIPTION
This PR makes the Redis master group configuration key more
      obvious. Redis "master" option still works, but "master_group"
      takes precedence.