### PR TITLE
Ensure Redis port is an integer

### DIFF
--- a/lib/sensu/redis/client.rb
+++ b/lib/sensu/redis/client.rb
@@ -16,7 +16,7 @@ module Sensu
       def initialize(options={})
         create_command_methods!
         @host = options[:host] || "127.0.0.1"
-        @port = options[:port] || 6379
+        @port = (options[:port] || 6379).to_i
         @db = options[:db]
         @password = options[:password]
         @auto_reconnect = options.fetch(:auto_reconnect, true)
@@ -102,7 +102,7 @@ module Sensu
               if ip_address.nil?
                 reconnect!
               else
-                reconnect(ip_address, port)
+                reconnect(ip_address, port.to_i)
               end
             end
           end

--- a/lib/sensu/redis/sentinel.rb
+++ b/lib/sensu/redis/sentinel.rb
@@ -25,7 +25,7 @@ module Sensu
       def connect_to_sentinel(options={})
         options[:host] ||= "127.0.0.1"
         options[:port] ||= 26379
-        EM.connect(options[:host], options[:port], Client, options)
+        EM.connect(options[:host], options[:port].to_i, Client, options)
       end
 
       # Connect to all Sentinel instances. This method defaults the


### PR DESCRIPTION
Some users try to use a string. This pull-request also ensures that port is an integer on reconnect.

Closes https://github.com/sensu/sensu/issues/1354