### PR TITLE
Support TLS encrypted Redis connections

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,4 @@ rvm:
   - jruby-9.1.7.0
 services:
   - redis
-script: "bundle exec rspec . --tag ~sentinel"
+script: "bundle exec rspec . --tag ~sentinel --tag ~tls"

--- a/lib/sensu/redis/client.rb
+++ b/lib/sensu/redis/client.rb
@@ -283,6 +283,20 @@ module Sensu
         end
       end
 
+      # This method is called by EM when the SSL/TLS handshake has
+      # been completed, as a result of calling #start_tls to initiate
+      # SSL/TLS on the connection. Log when the TLS handshake is
+      # complete.
+      def ssl_handshake_completed
+        if @logger
+          @logger.debug("redis tls handshake complete", {
+            :host => @host,
+            :port => @port,
+            :tls => @tls
+          })
+        end
+      end
+
       # Begin a multi bulk response array for an expected number of
       # responses. Using this method causes `dispatch_response()` to
       # wait until all of the expected responses have been added to

--- a/spec/redis_spec.rb
+++ b/spec/redis_spec.rb
@@ -47,4 +47,15 @@ describe "Sensu::Redis" do
       end
     end
   end
+
+  it "can connect to a redis instance with TLS", :tls => true do
+    async_wrapper do
+      Sensu::Redis.connect(:port => 6380, :tls => {}) do |redis|
+        redis.callback do
+          expect(redis.connected?).to eq(true)
+          async_done
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
This pull request adds TLS support to the Sensu Redis client.

Configuration:

To enable TLS:

```json
{
  "redis": {
    "host": "127.0.0.1",
    "port": 6380,
    "password": "secret",
    "tls": {}
  }
}
```

Alternatively, to match the RabbitMQ client options:

```json
{
  "redis": {
    "host": "127.0.0.1",
    "port": 6380,
    "password": "secret",
    "ssl": {}
  }
}
```

TLS options include `private_key_file`, `cert_chain_file`, and  `verify_peer`.

Closes https://github.com/sensu/sensu-redis/issues/17
